### PR TITLE
Fix/run test issue

### DIFF
--- a/lua/tman.lua
+++ b/lua/tman.lua
@@ -75,20 +75,20 @@ M.sendCommand = function(cmd, opt)
         height = tman.height,
     }
     local tbl = {
-        split = opt.split,
-        width = opt.width,
-        height = opt.height,
+        split = opt.split or oldTbl.split,
+        width = opt.width or oldTbl.width,
+        height = opt.height or oldTbl.height,
     }
     M.setup(tbl)
     if M.isTermValid() then
         vim.api.nvim_chan_send(tman.term, cmd)
     else
-        M.openTerm(tman.split)
+        M.openTerm(tbl.split)
         vim.api.nvim_chan_send(tman.term, cmd)
     end
     if opt.open then
         if not M.hasTermWin() then
-            M.openTerm(tman.split)
+            M.openTerm(tbl.split)
         end
     end
     tman.split = oldTbl.split

--- a/lua/tman.lua
+++ b/lua/tman.lua
@@ -13,6 +13,7 @@ tman.height =  40
 tman.lastSide = "bottom"
 
 M.setup = function (tbl)
+    tbl = M.validateAndGetWithSplit(tbl)
     tman.split = tbl.split or "bottom"
     tman.width = tbl.width or 50
     tman.height= tbl.height or 40
@@ -68,7 +69,18 @@ M.openTerm = function (split)
     tman.term = vim.b.terminal_job_id
 end
 
+M.validateAndGetWithSplit = function (opt)
+    if opt.split ~= nil then
+        if not (opt.split == "right" or opt.split == "bottom") then
+            vim.notify("Invalid split " .. opt.split, vim.log.levels.ERROR)
+            opt.split = tman.split
+        end
+    end
+    return opt
+end
+
 M.sendCommand = function(cmd, opt)
+    opt = M.validateAndGetWithSplit(opt)
     local oldTbl = {
         split = tman.split,
         width = tman.width,


### PR DESCRIPTION
there was a bug, with the terminal overriding one of the active splits if the split name is given incorrectly  in setup or when  calling sendCommand, this adds validation and fallback to the default value when the given split name is wrong
